### PR TITLE
26 add feature `Journal boundaries on a journal page` for seeking journal pages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import '@logseq/libs'; //https://plugins-doc.logseq.com/
-import { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin.user';
+import { LSPluginBaseInfo, SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin.user';
 import { setup as l10nSetup, t } from "logseq-l10n"; //https://github.com/sethyuan/logseq-l10n
 import ja from "./translations/ja.json";
-import { getISOWeek, getWeek, getWeekOfMonth } from 'date-fns';
-
+import { getISOWeek, getWeek, getWeekOfMonth, format, addDays, isBefore, isToday, isSunday, isSaturday } from 'date-fns';
 
 function formatRelativeDate(targetDate: Date): string {
   const currentDate = new Date();
@@ -92,20 +91,22 @@ function addExtendedDate(titleElement: HTMLElement) {
   }
   let printWeek;
   if (logseq.settings?.weekNumberOfTheYearOrMonth === "Year") {
-    printWeek = `<span title="week number within the year">${printWeekString}${weekNumber}<small>/y</small></span>`;
+    printWeek = `<span title="week number within the year">${printWeekString}<strong>${weekNumber}</strong><small>/y</small></span>`;
   } else {
-    printWeek = `<span title="week number within the month">${printWeekString}${weekNumber}<small>/m</small></span>`;
+    printWeek = `<span title="week number within the month">${printWeekString}<strong>${weekNumber}</strong><small>/m</small></span>`;
   }
   if (logseq.settings?.booleanDayOfWeek === true) {
     if (logseq.settings?.booleanWeekendsColor === true &&
-      dayOfWeekName === "Saturday" ||
-      dayOfWeekName === "Sunday" ||
-      dayOfWeekName === "土曜日" ||
-      dayOfWeekName === "日曜日") {
-      dateInfoElement.innerHTML = `<span class="weekends">${dayOfWeekName}</span>${printWeek}${relativeTime}`;
-    } else {
-      dateInfoElement.innerHTML = `<span>${dayOfWeekName}</span>${printWeek}${relativeTime}`;//textContent
-    }
+      isSaturday(journalDate) === true) {
+      dateInfoElement.innerHTML = `<span style="color:var(--ls-wb-stroke-color-blue)">${dayOfWeekName}</span>${printWeek}${relativeTime}`;
+    } else
+      if (logseq.settings?.booleanWeekendsColor === true &&
+        isSunday(journalDate) === true) {
+        dateInfoElement.innerHTML = `<span style="color:var(--ls-wb-stroke-color-red)">${dayOfWeekName}</span>${printWeek}${relativeTime}`;
+      }
+      else {
+        dateInfoElement.innerHTML = `<span>${dayOfWeekName}</span>${printWeek}${relativeTime}`;//textContent
+      }
   } else {
     dateInfoElement.innerHTML = `${printWeek}${relativeTime}`;
   }
@@ -128,7 +129,7 @@ const main = () => {
       await l10nSetup({ builtinTranslations: { ja } });
     } finally {
       /* user settings */
-      userSettings(ByLanguage);
+      logseq.useSettingsSchema(settingsTemplate(ByLanguage));
     }
   })();
 
@@ -141,19 +142,122 @@ const main = () => {
   :is(span.title,h1.title,a.page-title) span.weekday-and-week-number>span {
     margin-left: .75em;
   }
-  :is(span.title,h1.title,a.page-title) span.weekday-and-week-number span.weekends {
-    color:var(--ls-wb-stroke-color-red);
+  div#weekBoundaries {
+    display: flex;
+    margin-top: 1.0em;
+    padding: 0.85em;
+    overflow-x: scroll;
+    width: fit-content;
+  }
+  div#weekBoundaries>span.day {
+    opacity: .7;
+    width: 100px;
+    padding: 0.4em;
+    margin-left: 0.8em;
+    outline: 1px solid var(--ls-guideline-color);
+    outline-offset: 2px;
+    border-radius: 0.7em;
+    background: var(--color-level-1);
+  }
+  div#weekBoundaries>span.day span.dayOfWeek {
+    font-size: .9em;
+    font-weight: 600;
+  }
+  div#weekBoundaries>span.day span.dayOfMonth {
+    margin-left: .4em;
+    font-size: 1.5em;
+    font-weight: 900;
   }
   ` });
 
-  observer.observe(parent.document.getElementById("main-content-container") as HTMLElement, {
+  observer.observe(parent.document.getElementById("main-content-container") as HTMLDivElement, {
     attributes: true,
     subtree: true,
     attributeFilter: ["class"],
   });
 
+  logseq.App.onRouteChanged(async ({ template }) => {
+    if (logseq.settings?.booleanBoundaries === true && template === '/page/:name') { //journal '/'
+      //page only
+      boundaries();
+    }
+  });
+
+  logseq.onSettingsChanged((newSet: LSPluginBaseInfo['settings'], oldSet: LSPluginBaseInfo['settings']) => {
+    if (oldSet.booleanBoundaries === false && newSet.booleanBoundaries === true) {
+      boundaries();
+    } else
+      if (oldSet.booleanBoundaries === true && newSet.booleanBoundaries === false) {
+        const weekBoundaries = parent.document.getElementById('weekBoundaries');
+        if (weekBoundaries) weekBoundaries.remove();
+      }
+  });
+
+  logseq.beforeunload(async () => {
+    const titleElements = parent.document.querySelectorAll("span.weekday-and-week-number");
+    titleElements.forEach((titleElement) => {
+      titleElement.remove();
+    });
+    const weekBoundaries = parent.document.getElementById('weekBoundaries') as HTMLDivElement;
+    if (weekBoundaries) weekBoundaries.remove();
+    observer.disconnect();
+  });
+
 };/* end_main */
 
+
+//boundaries
+async function boundaries() {
+  const firstElement = (parent.document.getElementsByClassName('is-journals') as HTMLCollectionOf<HTMLDivElement>)[0];
+  if (firstElement) {
+    let weekBoundaries = parent.document.getElementById('weekBoundaries');
+    if (weekBoundaries) return;
+    weekBoundaries = parent.document.createElement('div');
+    weekBoundaries.id = 'weekBoundaries';
+    firstElement.insertBefore(weekBoundaries, firstElement.firstChild);
+    const titleElement = parent.document.querySelector("span.title");
+    if (!titleElement) return;
+    const targetDate: Date = parseDate(titleElement.textContent!);
+    if (!isFinite(Number(targetDate))) return;
+    const days = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4];
+    let { preferredDateFormat } = await logseq.App.getUserConfigs();
+    preferredDateFormat = preferredDateFormat.replace(/E{1,3}/, "EEE");//handle same E, EE, or EEE bug
+    days.forEach((numDays, index) => {
+      const date: Date = addDays(targetDate, numDays);
+      const dayOfWeek = format(date, 'EEE');
+      const dayOfMonth = format(date, 'd');
+      const dayElement = parent.document.createElement('span');
+      dayElement.classList.add('day');
+      dayElement.innerHTML = `<span class="dayOfWeek">${dayOfWeek}</span><span class="dayOfMonth">${dayOfMonth}</span>`;
+      if (logseq.settings?.booleanWeekendsColor === true && isSaturday(date) as boolean) {
+        dayElement.style.color = 'var(--ls-wb-stroke-color-blue)';
+      } else
+        if (logseq.settings?.booleanWeekendsColor === true && isSunday(date) as boolean) {
+          dayElement.style.color = 'var(--ls-wb-stroke-color-red)';
+        }
+      if (isToday(date)) {
+        dayElement.style.borderBottom = '3px solid var(--ls-wb-stroke-color-green)';
+        dayElement.style.cursor = 'pointer';
+        dayElement.style.opacity = "1.0";
+        dayElement.title = 'Today';
+      }
+      if (isBefore(date, new Date())) {
+        dayElement.style.cursor = 'pointer';
+        dayElement.addEventListener("click", async () => {
+          const journalPageName = format(date, preferredDateFormat);
+          const page = await logseq.Editor.getPage(journalPageName);
+          if (page) {
+            logseq.UI.showMsg('Jumping to the journal page', 'success');
+            logseq.App.pushState('page', { name: journalPageName });
+          } else {
+            logseq.UI.showMsg('No page found', 'warming');
+          }
+        });
+      }
+      weekBoundaries!.appendChild(dayElement);
+    });
+  }
+}
 
 
 //setCountry
@@ -179,68 +283,71 @@ function setCountry() {
 }
 //end
 
-function userSettings(ByLanguage) {
-  /* user setting */
-  // https://logseq.github.io/plugins/types/SettingSchemaDesc.html
 
-  const settingsTemplate: SettingSchemaDesc[] = [
-    {
-      key: "booleanWeekendsColor",
-      title: t("Coloring red to the word of Saturday or Sunday"),
-      type: "boolean",
-      default: true,
-      description: "",
-    },
-    {
-      key: "weekNumberFormat",
-      title: t("Week number format"),
-      type: "enum",
-      default: ByLanguage || "ISO(EU) format",
-      enumChoices: ["US format", "ISO(EU) format", "Japanese format"],
-      description: "",
-    },
-    {
-      key: "weekNumberOfTheYearOrMonth",
-      title: t("Show week number of the year or month (unit)"),
-      type: "enum",
-      default: "Year",
-      enumChoices: ["Year", "Month"],
-      description: "",
-    },
-    {
-      key: "booleanDayOfWeek",
-      title: t("Turn on/off day of the week"),
-      type: "boolean",
-      default: true,
-      description: "",
-    },
-    {
-      key: "booleanRelativeTime",
-      title: t("Turn on/off relative time"),
-      type: "boolean",
-      default: true,
-      description: t("like `3 days ago`"),
-    },
-    {
-      key: "localizeOrEnglish",
-      title: t("Select language default(Localize) or en(English)"),
-      type: "enum",
-      default: "default",
-      enumChoices: ["default", "en"],
-      description: "",
-    },
-    {
-      key: "longOrShort",
-      title: t("weekday long or short"),
-      type: "enum",
-      default: "long",
-      enumChoices: ["long", "short"],
-      description: "",
-    },
-  ];
-  logseq.useSettingsSchema(settingsTemplate);
-}
-
+/* user setting */
+// https://logseq.github.io/plugins/types/SettingSchemaDesc.html
+const settingsTemplate = (ByLanguage): SettingSchemaDesc[] => [
+  {
+    key: "booleanWeekendsColor",
+    title: t("Coloring to the word of Saturday or Sunday"),
+    type: "boolean",
+    default: true,
+    description: "",
+  },
+  {
+    key: "weekNumberFormat",
+    title: t("Week number format"),
+    type: "enum",
+    default: ByLanguage || "ISO(EU) format",
+    enumChoices: ["US format", "ISO(EU) format", "Japanese format"],
+    description: "",
+  },
+  {
+    key: "weekNumberOfTheYearOrMonth",
+    title: t("Show week number of the year or month (unit)"),
+    type: "enum",
+    default: "Year",
+    enumChoices: ["Year", "Month"],
+    description: "",
+  },
+  {
+    key: "booleanDayOfWeek",
+    title: t("Turn on/off day of the week"),
+    type: "boolean",
+    default: true,
+    description: "",
+  },
+  {
+    key: "booleanRelativeTime",
+    title: t("Turn on/off relative time"),
+    type: "boolean",
+    default: true,
+    description: t("like `3 days ago`"),
+  },
+  {
+    key: "localizeOrEnglish",
+    title: t("Select language default(Localize) or en(English)"),
+    type: "enum",
+    default: "default",
+    enumChoices: ["default", "en"],
+    description: "",
+  },
+  {
+    key: "longOrShort",
+    title: t("weekday long or short"),
+    type: "enum",
+    default: "long",
+    enumChoices: ["long", "short"],
+    description: "",
+  },
+  {
+    key: "booleanBoundaries",
+    title: t("Show the boundaries of 8 days before and after the day on a journal page."),
+    type: "boolean",
+    default: true,
+    description: "",
+  },
+];
 
 
 logseq.ready(main).catch(console.error);

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -1,10 +1,11 @@
 {
     "Week number format": "週番号フォーマット",
-    "Coloring red to the word of Saturday or Sunday": "土曜日と日曜日の文字を赤色にする",
+    "Coloring to the word of Saturday or Sunday": "土曜日と日曜日の文字を青色、赤色にする",
     "Show week number of the year or month (unit)": "週番号の単位(年または月)を変更する",
     "Turn on/off day of the week": "曜日を表示する",
     "Turn on/off relative time": "相対時間を表示する",
     "like `3 days ago`": "例: 昨日、3日前",
     "Select language default(Localize) or en(English)": "言語を選択する (「default」は日本語ローカライズ、「en」は英語)",
-    "weekday long or short": "曜日の表示形式 (長い形式または短い形式)"
+    "weekday long or short": "曜日の表示形式 (長い形式または短い形式)",
+    "Show the boundaries of 8 days before and after the day on a journal page.": "特定の日をページとして開いたときに、その日の前後8日間のナビゲーションバーを表示します。"
 }


### PR DESCRIPTION
### `Journal boundaries on a journal page`のプロトタイプ完成
   - 特定の日付ページを開いたときに表示する
   - ⚠️ときどき動作しないときがあるが不明

### バグ修正

#### 休日に色を付ける

   - 短縮形式の曜日では休日に色が反映されない
   - 土曜日は青、日曜日は赤に設定