### PR TITLE
feat(Update): Journal Boundaries date range and 2week mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@
 - Alignment of journal page title
   - `left` default
   - `space-around`
-- Select language default(Localize) or en(English): select
+- Select language Localize(:default) or English(:en): select
   - `default` default
   - `en`
 - Turn on/off the day of week: toggle
@@ -67,13 +67,29 @@
 - Turn on/off relative time: toggle
   - `true` default
   - `false`
-- Show the boundaries of 10 days before and after the day on the single journal page: toggle
+- Show the boundaries of days before and after the day on the single journal page: toggle
   - `true` default
   - `false`
 - Use the boundaries also on journals: toggle
   - `true` default
   - `false`
-- On the journal boundaries if no page found, create the journal page: toggle
+- The boundaries 2 week mode (only journals) [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
+  - `true`
+  - `false` default
+- The boundaries custom day range: before today (Excludes 2 week mode)  [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
+  - `11`
+  - `10`
+  - `9`
+  - `8`
+  - `7`
+  - `6` default
+  - `5`
+- The boundaries custom day range: after today (Excludes 2 week mode)  [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
+  - `3`
+  - `4` default
+  - `5`
+  - `6`
+- On the boundaries if no page found, create the journal page: toggle
   - `true`
   - `false` default
 - Use Weekly Journal feature: toggle
@@ -96,8 +112,8 @@
 ## Contributions
 
 - [Show week day and week number - discuss.logseq.com](https://discuss.logseq.com/t/show-week-day-and-week-number/12685/18)
-   - [danilofaria](https://discuss.logseq.com/u/danilofaria/)
-   - [ottodevs](https://discuss.logseq.com/u/ottodevs/)
+  - [danilofaria](https://discuss.logseq.com/u/danilofaria/)
+  - [ottodevs](https://discuss.logseq.com/u/ottodevs/)
 
 ## Showcase / Questions / Ideas / Help
 

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@
 - The boundaries 2 week mode (only journals) [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
   - `true`
   - `false` default
-- The boundaries custom day range: before today (Excludes 2 week mode)  [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
+- The boundaries custom day range: before today (Excludes 2 week mode) [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
   - `11`
   - `10`
   - `9`
@@ -84,7 +84,7 @@
   - `7`
   - `6` default
   - `5`
-- The boundaries custom day range: after today (Excludes 2 week mode)  [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
+- The boundaries custom day range: after today (Excludes 2 week mode) [#58](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/issues/58)
   - `3`
   - `4` default
   - `5`

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -6,12 +6,12 @@
     "Turn on/off day of the week": "曜日を表示する",
     "Turn on/off relative time": "相対時間を表示する",
     "like `3 days ago`": "例: 昨日、3日前",
-    "Select language Localize(:default) or English(en)": "言語を選択する (「default」は日本語ローカライズ、「en」は英語)",
+    "Select language Localize(:default) or English(:en)": "言語を選択する (「default」は日本語ローカライズ、「en」は英語)",
     "weekday long or short": "曜日の表示形式 (長い形式または短い形式)",
-    "Show the boundaries of 10 days before and after the day on the single journal page": "日付のページを開いたときに、前後の日付にアクセスできるナビゲーションバーを表示する",
+    "Show the boundaries of days before and after the day on the single journal page": "日付のページを開いたときに、前後の日付にアクセスできるナビゲーションバーを表示する",
     "Use the boundaries also on journals": "日誌(ジャーナル)を開いたときに、前後の日付にアクセスできるナビゲーションバーを表示する",
     "Turn on/off week number": "週番号を表示する",
-    "On the journal boundaries if no page found, create the journal page": "ナビゲーションバーの日付をクリックした際に、その日付のページが存在しない場合、ページを作成する(デフォルト: OFF)",
+    "On the boundaries if no page found, create the journal page": "ナビゲーションバーの日付をクリックした際に、その日付のページが存在しない場合、ページを作成する(デフォルト: OFF)",
     "Use Weekly Journal feature": "ウィークリージャーナルを有効にする",
     "Enable the link and function. If there is no content available on a page with a week number like 2023-W25, a template will be inserted.": "リンクと機能を有効にします。2023-W25のような週番号のページにコンテンツがない場合、テンプレートが挿入されます。",
     "Weekly Journal template name": "ウィークリージャーナルのテンプレート名",
@@ -19,5 +19,8 @@
     "Weekly Journal set page tag (Add to tags property)": "ウィークリージャーナルのページに設定するタグ (「tags」プロパティに追加)",
     "Input a page name (default is blank)": "ページ名を入力(1件のみ)。デフォルト: 空白",
     "Use `This Week` section of Weekly Journal": "ウィークリージャーナルの「This Week」セクションを使用する",
-    "Convert the day of the week in the `This Week` section of Weekly Journal into links.": "ウィークリージャーナルの「This Week」セクションの曜日をリンクに変換する"
+    "Convert the day of the week in the `This Week` section of Weekly Journal into links.": "ウィークリージャーナルの「This Week」セクションの曜日をリンクに変換する",
+    "The boundaries 2 week mode (only journals)": "ナビゲーションバーの日付範囲: 2週間モード",
+    "The boundaries custom day range: after today (Excludes 2 week mode)": "ナビゲーションバーの日付範囲: 今日より前の後の日数",
+    "The boundaries custom day range: before today (Excludes 2 week mode)": "ナビゲーションバーの日付範囲: 今日より前の日数"
 }


### PR DESCRIPTION
# Journal Boundaries

## デザイン改善

- 今週の日付を区別
  - opacity(CSS)を変更
-  2週間モード(Journalsのみ)

### プラグイン設定の項目追加

- 2週間モード(Journalsのみ)
- 日付範囲(2週間モード以外)