### PR TITLE
feat(Weekly Journal): Add the previous and following months to page-tag property if date format `yyyy-MM-dd` or `yyyy/MM/dd`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -448,6 +448,20 @@ async function currentPageIsWeeklyJournal(titleElement: HTMLElement, match: RegE
     weekDaysLinks.push(`${printNextYear}-W${(nextWeekNumber < 10)
       ? String("0" + nextWeekNumber)
       : String(nextWeekNumber)}`);
+
+    if (preferredDateFormat === "yyyy-MM-dd" || preferredDateFormat === "yyyy/MM/dd") {
+      //weekStartをもとに年と月を求め、リンクをつくる
+      const printYear = format(weekStart, "yyyy");
+      const printMonth = format(weekStart, "MM");
+      const printMonthLink = (preferredDateFormat === "yyyy-MM-dd") ? `${printYear}-${printMonth}` : `${printYear}/${printMonth}`;
+      weekDaysLinks.unshift(printMonthLink);
+      //weekEndをもとに年と月を求め、リンクをつくる
+      const printYear2 = format(weekEnd, "yyyy");
+      const printMonth2 = format(weekEnd, "MM");
+      const printMonthLink2 = (preferredDateFormat === "yyyy-MM-dd") ? `${printYear2}-${printMonth2}` : `${printYear2}/${printMonth2}`;
+      if (printMonthLink !== printMonthLink2) weekDaysLinks.push(printMonthLink2);
+    }
+    //ユーザー設定のページタグを追加
     if (logseq.settings!.weeklyJournalSetPageTag !== "") weekDaysLinks.push(logseq.settings!.weeklyJournalSetPageTag);
 
     //テンプレートを挿入


### PR DESCRIPTION
- 週の開始日および週の最後の日から年と月を取得
- 重複しないようにページタグへ追加する
![image](https://github.com/YU000jp/logseq-plugin-show-weekday-and-week-number/assets/111847207/6c3c909f-0c89-418e-a2ac-fe07a5c0938d)
