### PR TITLE
fix: detect Logseq OG (1.x) as MD model

### DIFF
--- a/src/logseqModelCheck.ts
+++ b/src/logseqModelCheck.ts
@@ -9,8 +9,11 @@ const checkLogseqVersion = async (): Promise<boolean> => {
     const version = logseqInfo.match(/(\d+)\.(\d+)\.(\d+)/)
     if (version) {
         replaceLogseqVersion(version[0]) // Update the version
-        // If the version is 0.10.* or lower, set logseqVersionMd to true.
-        if (version[0].match(/0\.([0-9]|10)\.\d+/)) {
+        // MD model: legacy file-based app (0.0.x - 0.10.x) or Logseq OG (1.x).
+        // DB-era apps report 0.11+ or 2.x.
+        const major = Number(version[1])
+        const minor = Number(version[2])
+        if ((major === 0 && minor <= 10) || major === 1) {
             return true
         }
     } else {


### PR DESCRIPTION
Fixes #182

Logseq OG reports version `1.0.0`, but `checkLogseqVersion()` only accepts `0.0.x`-`0.10.x` as the MD model - so on OG the plugin silently runs in DB mode on markdown graphs and MD-only features (beside-title weekday, two-line calendar) do not render.

This change treats 1.x as the MD model. DB-era apps report `0.11+` or `2.x`, so DB detection is unchanged.

**Testing note:** I have not built this branch from source. I applied the equivalent version-check change to the released v1.72.1 `dist` bundle (edited the minified check in place) running on Logseq OG 1.0.0 (macOS, markdown graph): the beside-title display and two-line calendar render again, and the DB-graph warning no longer fires. The `2.0.1` (DB app) version string still fails the new check by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)